### PR TITLE
Changed the way of resetting index of the dataframe PR#18

### DIFF
--- a/intents/topk.py
+++ b/intents/topk.py
@@ -101,6 +101,7 @@ https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior
     table = table.sort_values(by=[metric], ascending=is_asc)
     
     # reordering the index
+    # drop=True drops the new columnn named 'index' created in reset_index call
     table = table.reset_index(drop=True)
 
     # selecting only the top-k

--- a/intents/topk.py
+++ b/intents/topk.py
@@ -101,8 +101,7 @@ https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior
     table = table.sort_values(by=[metric], ascending=is_asc)
     
     # reordering the index
-    table = table.reset_index()
-    table = table.drop(['index'], axis=1)
+    table = table.reset_index(drop=True)
 
     # selecting only the top-k
     table = table.head(k)

--- a/intents/util/aspects.py
+++ b/intents/util/aspects.py
@@ -55,8 +55,8 @@ https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior
         end_date = datetime.datetime.strptime(date_range[1], date_format)
         if row_date < start_date or end_date < row_date:
             table = table.drop([row])
+    # drop=True drops the new columnn named 'index' created in reset_index call
     table = table.reset_index(drop=True)
-    # table = table.drop(['index'], axis=1)
     return table
 
 def slice_table(table, slices):
@@ -85,9 +85,8 @@ def slice_table(table, slices):
             table = table.drop([row])
 
     #some indices get deleted after slicing
+    # drop=True drops the new columnn named 'index' created in reset_index call
     table = table.reset_index(drop=True)
-    # droping the new columnn named 'index' created after reset_index call
-    # table = table.drop(['index'], axis=1)
     return table
 
 def crop_other_columns(table, required_columns):

--- a/intents/util/aspects.py
+++ b/intents/util/aspects.py
@@ -55,8 +55,8 @@ https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior
         end_date = datetime.datetime.strptime(date_range[1], date_format)
         if row_date < start_date or end_date < row_date:
             table = table.drop([row])
-    table = table.reset_index()
-    table = table.drop(['index'], axis=1)
+    table = table.reset_index(drop=True)
+    # table = table.drop(['index'], axis=1)
     return table
 
 def slice_table(table, slices):
@@ -85,9 +85,9 @@ def slice_table(table, slices):
             table = table.drop([row])
 
     #some indices get deleted after slicing
-    table = table.reset_index()
+    table = table.reset_index(drop=True)
     # droping the new columnn named 'index' created after reset_index call
-    table = table.drop(['index'], axis=1)
+    # table = table.drop(['index'], axis=1)
     return table
 
 def crop_other_columns(table, required_columns):


### PR DESCRIPTION
The reset_index functions created an extra column named 'index', and in some cases 'level_0'. 
It is better to drop it by the keyword arguments `drop=True`. The tests still pass. Also, other intents don't get affected by this.
PR #18 