### PR TITLE
Sort kind updated to a stable sort 'mergesort'

### DIFF
--- a/intents/test_topk.py
+++ b/intents/test_topk.py
@@ -195,9 +195,9 @@ def test_7():
 22      Mary Johnson  178345
 23       Karen Scott  205187
 24        Mark Young  205187
-25   Joseph Thompson  212156
+25   Lawrence Sperry  212156
 26   Angela Martinez  212156
-27   Lawrence Sperry  212156
+27   Joseph Thompson  212156
 28       Betty Adams  227489
 29       Lisa Walker  256481
 30     George Wright  289950"""

--- a/intents/topk.py
+++ b/intents/topk.py
@@ -208,7 +208,9 @@ https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior
 
     table = aspects.group_by(table, dimensions, summary_operator)
 
-    table = table.sort_values(by=[metric], ascending=is_asc)
+    # using a stable sort('mergesort') will help to preserve the order
+    # if equal values of [metric] are present
+    table = table.sort_values(by=[metric], ascending=is_asc, kind = 'mergesort')
 
     # reordering the index
     # drop=True drops the new columnn named 'index' created in reset_index call


### PR DESCRIPTION
Main Changes
- In top-k the `sort_values` function used an unstable sort by default (which means the rows with same values are ranked 
arbitrarily ), so changed it to a stable sort kind `mergesort`.
- Now if there are multiple rows with same value of `[metric]`, their ranking in the original table will be preserved
- Updated expected results in test_topk.py

Link to [Issue](https://github.com/pandas-dev/pandas/issues/35511#issuecomment-667688520)
